### PR TITLE
Doc/el v02 documentation

### DIFF
--- a/EXTRACT.md
+++ b/EXTRACT.md
@@ -1,0 +1,105 @@
+# Extraction de Données
+
+Les sources de données utiles au projet sont diverses avec chacune leurs spécificités mais peuvent présenter certaines caractéristiques communes : beaucoup sont des sources OpenData exposant des API suivant le standard REST, certaines suivent le standard spécifique OpendataSoft, la plupart permettent de récupérer des données sous format JSON et CSV, etc…
+
+Les spécificités de chacune se situent souvent dans la structure de leurs champs, le nom des paramètres à passer, les URL à trouver et appeler, les contraintes à respecter :
+
+- taille de fichiers, pagination ( = découpage des résultats en plusieurs morceaux )
+- ne pas dépasser une certaine fréquence d’appels ( throttling )
+- certains paramètres à passer dans les requêtes, des headers à préciser…
+- dans certains cas (plutôt rares), présenter une authentification ( = un mot de passe ou équivalent)
+
+Pour rendre l’extraction de ces diverses sources facilement extensible (ie permettre de rapidement rajouter des nouvelles sources d’extraction sans trop de code) tout ne restant assez flexible pour s’adapter aux spécificités de chacune, nous avons adopté une approche basée sur des configurations déclaratives, et des objets Extracteurs.
+
+## Extractors
+
+Les Extractors sont des classes Python, définies dans le fichier `common/utils/source_extractors.py`. Chaque Extractor déclare une méthode `extract` servant à requêter des API, et récupérer ce qui sort pour le stocker dans un format adéquat (JSON ou CSV par exemple), ou bien le passer à une autre fonction Python qui continuerait la chaîne d’ELT.
+
+Un Extractor peut être assez générique, pour être réutilisé dans divers cas : `FileExtractor` par exemple, qui récupère un fichier entier depuis n’importe quelle API http sans authentification ni pagination. Ou au contraire très spécifique et adapté à un cas particulier : récupérer une API avec des contraintes très particulières d’authentification, de format, de pagination par exemple.
+
+Les Extractors sont dérivés d’une classe abstraite `SourceExtractor` qui définit certaines propriétés et méthodes communes, qui sont donc héritées et utilisable par tout Extracteur. En particulier, la fonction `set_query_parameters` qui permet d’interpréter la configuration déclarative et prépare les différents paramètres pour envoyer une requête à une API.
+
+## Configuration déclarative des sources
+
+Le fichier `datasources.yaml` répertorie toutes nos sources de données et est organisé autour de trois grandes notions :
+
+- Les API sur lesquelles on va chercher la donnée ( APIs INSEE, API du ministère du logement, etc…)
+- Les “Domaines” de donnée qui regroupent les jeux de données en thématiques : géographie, logement, emploi etc
+- Au sein de chaque Domaine, des “Sources” qui représentent les informations sur les jeux de données précis à récupérer
+
+Les définitions sont données dans un fichier yaml pour être facilement lisibles et extensibles. Le fichier est organisé en deux grands blocs :
+
+### Définition des API
+
+Les API sont définies dans le bloc `APIs` :
+
+```yaml
+APIs:
+
+  INSEE.Metadonnees:
+    name: Metadonnees INSEE
+    description: INSEE - API des métadonnées
+    base_url: https://api.insee.fr/metadonnees/V1
+    apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+    default_headers:
+        accept: application/json
+```
+
+Un bloc de définition d’une API comporte obligatoirement: 
+
+- `name` et `description` : Des informations générales destinées à faciliter la lecture et la compréhension par des humains
+- `apidoc` : Un lien vers la documentation technique de l’API (le swagger par exemple)
+- `base_url` : L’URL à la base de tous les appels
+
+Optionnellement, un bloc API peut déclarer toute information utile pour prendre en compte les contraintes de l’API : headers à passer, paramètres obligatoires, paramètres de pagination, etc…
+
+### Définition des modèles Sources
+
+Les jeux de données Source sont organisées par domaine, dans le bloc `domains` :
+
+```yaml
+domains:
+
+  geographical_references:
+
+    regions:
+      API: INSEE.Metadonnees
+      description: Référentiel géographique INSEE - niveau régional
+      type: JsonExtractor
+      urlpath: /geo/regions
+
+    departements:
+      API: INSEE.Metadonnees
+      description: Référentiel géographique INSEE - niveau départemental
+      type: JsonExtractor
+      urlpath: /geo/departements
+```
+
+Dans l’exemple ci-dessus, est déclaré le domaine “geographical_references”, qui contient les modèles source pour les jeux de donnée “régions” et “départements” du référentiel géographique de l’INSEE.
+
+Un bloc “source” définit obligatoirement les champs suivants :
+
+- `API` : quelle API est à la source de ce dataset
+- `description` : description claire et concise pour aider à la compréhension
+- `type` : quel type d’Extracteur doit être utilisé pour récupérer ce dataset
+- `urlpath` : comment l’URL de l’API doit être complétée pour requêter ce jeu de données
+
+Dans l’exemple donné, pour récupérer le dataset “regions”, un Extracteur de classe “JsonExtractor” sera donc instancié, pour requêter l’API INSEE.Metadonnees sur l’URL complète suivante :
+
+`https://api.insee.fr/metadonnees/v1/geo/regions`
+
+## Comment ajouter des nouvelles sources
+
+Pour ajouter des nouveaux dataset sources à extraire, il faut donc en prérequis, avoir exploré et identifié quelles API et quelles jeux de données sont intéressants, et avoir compris comment lesdites API fonctionnent.
+
+Une fois que vous savez ce que vous voulez récupérer, il faut ajouter une ou deux choses au code :
+
+1. Créer une nouvelle branche “feat” à partir de “main”, et associée à une Task dans le board Github
+2. Ajouter les déclarations d’API, domaine et sources dans `datasources.yaml` , selon le format décrit plus haut
+3. Si aucun des Extractors existants dans `common/utils/source_extractors.py` ne convient aux besoins et contraintes de l’API que vous ciblez, vous pouvez soit modifier un Extractor existant, soit en créer un nouveau adapté à vos besoins, en respectant les deux contraintes suivantes :
+    1. Tout Extractor doit hériter de `SourceExtractor`
+    2. Tout Extractor doit définir une méthode `extract`
+4. La valeur du champ `type` pour vos définitions de sources dans la config doit correspondre exactement au nom de votre classe d'extracteur (par exemple FileExtractor)
+5. Tester en local, et une fois que ça marche pour vous, soumettre une PR 
+
+Good luck 🙂

--- a/EXTRACT.md
+++ b/EXTRACT.md
@@ -82,7 +82,7 @@ Un bloc “source” définit obligatoirement les champs suivants :
 - `API` : quelle API est à la source de ce dataset
 - `description` : description claire et concise pour aider à la compréhension
 - `type` : quel type d’Extracteur doit être utilisé pour récupérer ce dataset
-- `urlpath` : c'est un endpoint(point de terminaison) permettant d'accèder au jeu de données
+- `endpoint` : c'est un endpoint (point de terminaison) permettant d'accèder au jeu de données. C'est ce qui doit compléter l'URL de base de l'API pour trouver un jeu de données
   
 Dans l’exemple donné, pour récupérer le dataset “regions”, un Extracteur de classe “JsonExtractor” sera donc instancié, pour requêter l’API INSEE.Metadonnees sur l’URL complète suivante :
 

--- a/EXTRACT.md
+++ b/EXTRACT.md
@@ -9,7 +9,7 @@ Les spécificités de chacune se situent souvent dans la structure de leurs cham
 - certains paramètres à passer dans les requêtes, des headers à préciser…
 - dans certains cas (plutôt rares), présenter une authentification ( = un mot de passe ou équivalent)
 
-Pour rendre l’extraction de ces diverses sources facilement extensible (ie permettre de rapidement rajouter des nouvelles sources d’extraction sans trop de code) tout ne restant assez flexible pour s’adapter aux spécificités de chacune, nous avons adopté une approche basée sur des configurations déclaratives, et des objets Extracteurs.
+Pour rendre l’extraction de ces diverses sources facilement extensible (ie permettre de rapidement rajouter des nouvelles sources d’extraction sans trop de code) tout en restant assez flexible pour s’adapter aux spécificités de chacune, nous avons adopté une approche basée sur des configurations déclaratives, et des objets Extracteurs.
 
 ## Extractors
 
@@ -82,8 +82,8 @@ Un bloc “source” définit obligatoirement les champs suivants :
 - `API` : quelle API est à la source de ce dataset
 - `description` : description claire et concise pour aider à la compréhension
 - `type` : quel type d’Extracteur doit être utilisé pour récupérer ce dataset
-- `urlpath` : comment l’URL de l’API doit être complétée pour requêter ce jeu de données
-
+- `urlpath` : c'est un endpoint(point de terminaison) permettant d'accèder au jeu de données
+  
 Dans l’exemple donné, pour récupérer le dataset “regions”, un Extracteur de classe “JsonExtractor” sera donc instancié, pour requêter l’API INSEE.Metadonnees sur l’URL complète suivante :
 
 `https://api.insee.fr/metadonnees/v1/geo/regions`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pour comprendre en détail comment ça marche, et comprendre comment ajouter des
 
 ## Chargement des données brutes
 
-Le script [load.py](http://load.py) permet de charger un fichier local dans la base de données.
+Le script `load.py` permet de charger un fichier local dans la base de données.
 
 ```bash
 poetry run python bin/load.py --domain geographical_references

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # OD&IS
 
-À compléter...
+DataForGood saison 13. 
 
-DataForGood saison 13.
+OD&IS est une application permettant à l’association J’Accueille de visualiser des données utiles à l’insertion et l’implantation de personnes en situation de migration, vers des territoires adaptés à leurs besoins en termes de logement, santé, services publics, éducation etc…
+
+Le but de ce projet est de récupérer et traiter les différentes sources de données utiles, de façon fiable, répétable et régulièrement mise à jour.
 
 ## Installation
 
@@ -14,7 +16,7 @@ cp .env.dist .env
 poetry install
 ```
 
-## Pour démarrer la base de données en local
+Ce projet utilise une base de données PostgreSQL. Pour démarrer la base de données en local :
 
 ```bash
 docker compose up -d
@@ -22,30 +24,74 @@ docker compose up -d
 
 La base de données sera ensuite accessible sur `localhost:5432`
 
-## Pour initialiser ou réinitialiser la base de données
+Pour initialiser ou réinitialiser la base de données :
 
-```
+```bash
 poetry run python bin/db.py init
 ```
 
-## Pipeline ELT
+## Approche : ELT + architecture médaillon
 
-### Approche
+Pour récupérer les données et les modeler selon les besoins de J’Accueille, ce projet implémente une approche ELT : Extract-Load-Transform.
 
-Ce projet utilise une architecture en "médaillon" avec trois niveaux de traitement des données : bronze (données brutes), silver (données nettoyées) et gold (données traitées prêtes à l'emploi). Les sources de données sont classées par domaines dans le fichier `datasources.yaml`. Des scripts dédiés gèrent l'extraction et le chargement des données dans la base, tandis que les transformations entre niveaux sont effectuées via DBT.
+L’architecture de données est dite en "médaillon" avec trois niveaux de “maturité” des données : bronze (données brutes), silver (données nettoyées, recoupées) et gold (données traitées prêtes à l'emploi pour l’application). 
 
-### Extraction
+Une approche ELT avec une architecture de données en médaillon, ça donne donc la suite de tâches suivante :
+
+1. On extrait les données OpenData de toutes nos sources intéressantes ( = Extract )
+2. On charge toutes ces données brutes dans la couche “bronze” de la base ( = Load )
+3. On effectue toutes les transformations nécessaires pour aller de la couche Bronze à la Silver puis la Gold ( = Transform )
+
+## Extraction
+
+L’extraction de données se fait grâce à des Extracteurs (des classes Python), qui se basent sur le fichier de configuration “datasources.yaml”, et appellent les différentes API ciblées.
+
+Le fichier “datasources.yaml” répertorie toutes nos sources de données et est organisé autour de trois grandes notions :
+
+- Les API sur lesquelles on va chercher la donnée ( APIs INSEE, API du ministère du logement, etc…)
+- Les “Domaines” de donnée qui regroupent les jeux de données en thématiques : géographie, logement, emploi etc
+- Au sein de chaque Domaine, des “Sources” qui représentent les informations sur les jeux de données précis à récupérer
+
+Le script “extract.py” permet de récupérer des jeux de données en ligne de commande, en choisissant un Domaine, et un ou plusieurs Sources. Par défaut, si on ne précise pas de Source, les données sont extraites pour toutes les Sources définies pour le Domaine choisi.
 
 ```bash
+# Extraire tous les datasets source du domaine "geographical_references"
 poetry run python bin/extract.py --domain geographical_references
+
+# Extraire seulement les datasets "regions" et "departements du domaine "geographical_references"
+poetry run python bin/extract.py --domain geographical_references --sources regions departements
 ```
 
-### Chargement des données bruts
+L’option “explain” permet de voir facilement comment les API, Domaines et Sources sont définis dans la configuration. Si l’option “explain” est passée, le script n’extrait aucune donnée mais montre seulement les infos sur les configurations demandées.
+
+```bash
+# Voir la liste des API, domaines et sources disponibles
+poetry run python bin/extract.py --explain
+
+# Voir les définitions de tous les datasets source du domaine "geographical_references"
+poetry run python bin/extract.py --explain --domain geographical_references 
+
+# Voir les définitions détaillées de l'API DiDo
+poetry run python bin/extract.py --explain --api DiDo
+
+# Voir les définitions détaillées de plusieurs API INSEE
+poetry run python bin/extract.py --explain --api INSEE.Melodi INSEE.Metadonneees
+
+# Voir les définitions détaillées d'une source de données et de son API
+poetry run python bin/extract.py --explain --api DiDo --domain logement --source dido_catalogue 
+```
+
+Pour comprendre en détail comment ça marche, et comprendre comment ajouter des Extracteurs et aller chercher des nouvelles sources de données, c’est ici :
+
+- [Extractors](./EXTRACT.md)
+
+## Chargement des données brutes
+
+Le script [load.py](http://load.py) permet de charger un fichier local dans la base de données.
 
 ```bash
 poetry run python bin/load.py --domain geographical_references
 ```
-
 
 ## Télécharger la méthodologie et les modèles de données cibles
 
@@ -53,4 +99,5 @@ Il s'agit d'une méthodologie reprenant les opérations de transformation effect
 
 ```bash
 poetry run python ./common/utils/download_target_data.py
+
 ```

--- a/common/utils/source_extractors.py
+++ b/common/utils/source_extractors.py
@@ -55,7 +55,7 @@ class SourceExtractor(ABC):
         base_split = urllib.parse.urlsplit(base_url)
 
         # expand the query path with the source config
-        full_path = f"{base_split.path}{source_model['urlpath']}"
+        full_path = f"{base_split.path}{source_model['endpoint']}"
         
         # rebuild the full URL with complete path
         self.url = urllib.parse.urljoin(f"https://{base_split.netloc}", full_path)

--- a/datasources.yaml
+++ b/datasources.yaml
@@ -48,19 +48,19 @@ domains:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau régional
       type: JsonExtractor
-      urlpath: /geo/regions
+      endpoint: /geo/regions
 
     departements:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau départemental
       type: JsonExtractor
-      urlpath: /geo/departements
+      endpoint: /geo/departements
 
     communes:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau commune
       type: JsonExtractor
-      urlpath: /geo/communes
+      endpoint: /geo/communes
 
   logement:
 
@@ -68,7 +68,7 @@ domains:
         API: DiDo
         description: Catalogue de tous les datasets dispo sur l'API DiDo (logement / développement durable)
         type: JsonExtractor
-        urlpath: /datasets
+        endpoint: /datasets
         params:
           page: 1
           pageSize: all
@@ -77,7 +77,7 @@ domains:
         API: DiDo
         description: Données Annuelles Départementales de l'API DiDo
         type: FileExtractor
-        urlpath: /datafiles/a0ae7112-5184-4ad7-842d-87b09fd27df1/csv
+        endpoint: /datafiles/a0ae7112-5184-4ad7-842d-87b09fd27df1/csv
         format: csv
         params:
           withColumnName: true

--- a/datasources.yaml
+++ b/datasources.yaml
@@ -47,19 +47,19 @@ domains:
     regions:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau régional
-      type: json_extractor
+      type: JsonExtractor
       urlpath: /geo/regions
 
     departements:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau départemental
-      type: json_extractor
+      type: JsonExtractor
       urlpath: /geo/departements
 
     communes:
       API: INSEE.Metadonnees
       description: Référentiel géographique INSEE - niveau commune
-      type: json_extractor
+      type: JsonExtractor
       urlpath: /geo/communes
 
   logement:
@@ -67,7 +67,7 @@ domains:
       dido_catalogue:
         API: DiDo
         description: Catalogue de tous les datasets dispo sur l'API DiDo (logement / développement durable)
-        type: json_extractor
+        type: JsonExtractor
         urlpath: /datasets
         params:
           page: 1
@@ -76,7 +76,7 @@ domains:
       annual_dept_data:
         API: DiDo
         description: Données Annuelles Départementales de l'API DiDo
-        type: file_extractor
+        type: FileExtractor
         urlpath: /datafiles/a0ae7112-5184-4ad7-842d-87b09fd27df1/csv
         format: csv
         params:


### PR DESCRIPTION
J'ai fait un tout petit peu plus que d'ajouter de la documentation 😇 

Pour faciliter l'extension et l'ajout de nouveaux Extractors, j'ai modifié la méthode `get_source_extractors.py` pour qu'elle importe directement les bonnes classes d'après la valeur récupérée dans `datasources.yaml`. 
Ca évite de devoir modifier un dict dans cette méthode à chaque fois qu'on ajoute un extracteur.

En gros (et comme mis dans la doc associée), pour ajouter un nouvel extracteur on doit "simplement" coder la classe dans `source_extractors.py`, et l'utiliser dans la config yaml en donnant le nom exact de la classe dans le champ "type" d'un bloc "source".

A dispo si besoin de clarification