### PR TITLE
Fix - Ajout d'un répertoire log vide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ data/imports/*
 dbt_odis/seeds/*
 !dbt_odis/seeds/.gitkeep
 log/*
+!log/.gitkeep


### PR DESCRIPTION
Pour le bon fonctionnement du logger (évite les erreurs de répertoire non existant)