### PR TITLE
Refactored data loaders to use same metadata format as extractors, put back line-by-line json loader, added unit tests

### DIFF
--- a/bin/odis.py
+++ b/bin/odis.py
@@ -113,7 +113,7 @@ def load(
         try:
 
             loader = create_loader(config, model)
-            loader.load_data()
+            loader.execute()
 
         except Exception as e:
 

--- a/common/data_source_model.py
+++ b/common/data_source_model.py
@@ -58,7 +58,8 @@ class DomainModel(BaseModel):
         endpoint="/regions",
         description="Regions in France",
         headers=HeaderModel(accept="application/json"),
-        params={"key": "value"},
+        extract_params={"key": "value"},
+        load_params={"key": "value"},
         response_map={"next": "paging.next"},
         format="json",
     )
@@ -75,10 +76,16 @@ class DomainModel(BaseModel):
         description="headers to be sent with the request",
     )
 
-    params: Optional[dict] = Field(
+    extract_params: Optional[dict] = Field(
         default=None,
         examples=[{"key": "value", "key2": 1.2}],
         description="arbitrary query parameters passed to the API",
+    )
+
+    load_params: Optional[dict] = Field(
+        default=None,
+        examples=[{"key": "value", "key2": 1.2}],
+        description="Parameters to be passed to the Loader",
     )
 
     response_map: Optional[dict] = Field(

--- a/common/data_source_model.py
+++ b/common/data_source_model.py
@@ -128,12 +128,12 @@ class DomainModel(BaseModel):
 
         Example:
         ```python
-        DomainModel(name="Metadonnees.INSEE")
-        # table_name would be "INSEE"
+        DomainModel(name="logement.dido")
+        # table_name would be "logement_dido"
         ```
         """
         if self.name:
-            return self.name.split(".")[-1]
+            return self.name.replace(".","_")
         return None
 
 
@@ -299,89 +299,3 @@ class DataSourceModel(ConfigurationModel):
                 return api
 
         raise ValueError(f"API '{model.API}' not found in APIs section")
-
-
-@dataclass
-class PageLog:
-    """model for easily updating and logging information about the processing of a given page"""
-
-    pageno: int
-    filepath: Optional[str] = None  # to be enhanced ; needs to be a valid path
-    is_last: Optional[bool] = False
-    extracted: Optional[bool] = False
-    bronze_loaded: Optional[bool] = False
-
-
-@dataclass
-class DataProcessLog:
-    """model for exchanging processing reports between extractors and loaders"""
-
-    domain: str
-    source: str
-    operation: str
-    last_run_time: str = field(
-        default_factory=lambda: datetime.datetime.now().strftime("%Y-%m-%d, %H:%M:%S")
-    )
-    exctracted_pages: int = 0
-    loaded_pages: int = 0
-    successfully_completed: bool = False
-    source_config: dict = None
-    pages: dict[PageLog] = field(default_factory=dict)
-
-    @classmethod
-    def from_dict(cls, dict_data):
-
-        processed_dict_data = dict_data
-
-        # Pop out dict-type pagelogs to reinsert PageLog types
-        pagelogs = {}
-        pages_dict = processed_dict_data.pop("pages")
-        for pageno, pagelog_dict in pages_dict.items():
-            pagelog = PageLog(**pagelog_dict)
-            pagelogs[pageno] = pagelog
-
-        processed_dict_data["pages"] = pagelogs
-
-        return cls(**processed_dict_data)
-
-    def to_dict(self):
-
-        raw_dict = self.__dict__
-        serialized_pagelogs = {}
-        for pageno, pagelog in self.pages.items():
-            serialized_pagelogs[pageno] = pagelog.__dict__
-
-        # replace the PageLog list by serializable list(dict)
-        raw_dict.pop("pages")
-        serialized_dict = raw_dict
-        serialized_dict["pages"] = serialized_pagelogs
-
-        return serialized_dict
-
-    def update_pagelog(self, pageno: int, **pagelog_params):
-        """Creates or Updates a PageLog with the information of how its last processing (extract or load) went"""
-
-        pagelog = self.pages.get(str(pageno))
-
-        if pagelog is None:
-            # if pagenumber was not found, create a new PageLog
-            pagelog = PageLog(pageno, **pagelog_params)
-
-        else:
-            # Update PageLog in place
-            for key, value in pagelog_params.items():
-                setattr(pagelog, key, value)
-
-        # Add page log to pages
-        self.pages[pageno] = pagelog
-
-        # If relevant, increment the extracted pages count
-        if self.operation == "extract" and pagelog.extracted:
-            self.exctracted_pages += 1
-
-        # If relevant, increment the loaded pages count
-        if self.operation == "load" and pagelog.bronze_loaded:
-            self.loaded_pages += 1
-
-        # If this page was the last, then infer process is successful and complete
-        self.successfully_completed = pagelog.is_last

--- a/common/tests/stubs/data_handler.py
+++ b/common/tests/stubs/data_handler.py
@@ -1,5 +1,11 @@
-from common.utils.interfaces.data_handler import IDataHandler, StorageInfo
+from common.utils.interfaces.data_handler import (
+    IDataHandler, 
+    StorageInfo, 
+    PageLog, 
+    MetadataInfo
+)
 
+import datetime
 
 class StubDataHandler(IDataHandler):
     """used to test the JsonExtractor class"""
@@ -12,3 +18,86 @@ class StubDataHandler(IDataHandler):
         return StorageInfo(
             location="test", format="test", file_name="test", encoding="test"
         )
+
+class StubPageLog(PageLog):
+
+    def __init__(self):
+        
+        page = 1
+        storage_info = StorageInfo(
+            location = "data/imports",
+            format = "json",
+            file_name = "logement.logements_maison_et_residences_principales_1.json",
+            encoding = "utf-8"
+        )
+        is_last = False
+        extracted = True
+        loaded = False
+
+        super().__init__(self, page, storage_info, is_last, extracted, loaded)
+
+class StubMetadataInfo(MetadataInfo):
+
+    def to_dict(self):
+        super().to_dict(self)
+
+    @classmethod
+    def from_dict():
+
+        stub_model = {
+            'API': 'INSEE.Melodi',
+            'description': "nombre de maison",
+            'type': 'MelodiExtractor',
+            'endpoint': '/data/DS_RP_LOGEMENT_PRINC',
+            'format': 'json',
+            'extract_params': {
+                'maxResult': 10000,
+                'TIME_PERIOD': 2021,
+                'GEO': ["COM", "DEP", "REG"],
+                'RP_MEASURE': 'DWELLINGS',
+                'L_STAY': '_T',
+                'TOH': '_T',
+                'CARS': '_T',
+                'NOR': '_T',
+                'TSH': '_T',
+                'BUILD_END': '_T',
+                'OCS': '_T',
+                'TDW': 1
+            },
+            'response_map': {
+                'data': 'observations',
+                'next': 'paging.next',
+                'is_last': 'paging.isLast'
+            }
+        }
+
+        nb_pages = 4
+        stub_pages = {}
+        for i in range(1,nb_pages):
+            stub_pages[i] = {
+                'page': i,
+                'storage_info': {
+                    'location': "data/imports",
+                    'format': "json",
+                    'file_name': f"logement.logements_maison_et_residences_principales_{i}.json",
+                    'encoding':"utf-8"
+                },
+                'is_last': False,
+                'extracted': True,
+                'loaded': False
+            }
+        stub_pages[nb_pages]['is_last'] = True
+        
+        stub_metadata = {
+            'domain': 'logement',
+            'source': 'logements_maisons',
+            'operation': 'extract',
+            'last_run_time': datetime.datetime.now(tz=datetime.datetime.utc),
+            'extracted_pages': 4,
+            'loaded_pages': 0,
+            'successfully_completed': True,
+            'model': stub_model,
+            'pages': stub_pages
+        }
+
+        super().from_dict( stub_metadata )

--- a/common/tests/test_data_handler.py
+++ b/common/tests/test_data_handler.py
@@ -1,0 +1,10 @@
+from common.utils.interfaces.data_handler import MetadataInfo
+from .stubs.data_handler import StubMetadataInfo
+
+def test_metadata_info():
+    # To be improved
+
+    stub_metadata = StubMetadataInfo.from_dict()
+    print(stub_metadata.to_dict())
+
+    assert type(stub_metadata) is MetadataInfo

--- a/common/utils/data_loaders.py
+++ b/common/utils/data_loaders.py
@@ -5,10 +5,10 @@ import jmespath
 import pandas as pd
 from psycopg2.extras import Json
 
-from common.data_source_model import DataProcessLog
 from common.utils.database_client import DatabaseClient
 from common.utils.interfaces.data_loader import AbstractDataLoader
 from common.utils.logging_odis import logger
+from common.data_source_model import DataProcessLog
 
 
 class JsonDataLoader(AbstractDataLoader):
@@ -160,9 +160,9 @@ class CsvDataLoader(AbstractDataLoader):
 
         domain_name = self.config.get_domain_name(self.model)
         # Extract CSV-specific parameters
-        header = self.model.params.get("header", None)
-        skipfooter = self.model.params.get("skipfooter", None)
-        separator = self.model.params.get("separator", ",")
+        header = self.model.load_params.get("header", None)
+        skipfooter = self.model.load_params.get("skipfooter", None)
+        separator = self.model.load_params.get("separator", ",")
 
         db = DatabaseClient(autocommit=False)
 

--- a/common/utils/interfaces/data_handler.py
+++ b/common/utils/interfaces/data_handler.py
@@ -2,6 +2,7 @@ from typing import Any, Protocol
 
 from pandas import DataFrame
 from pydantic import BaseModel, NonNegativeInt
+from typing import Optional
 
 from common.data_source_model import DomainModel
 
@@ -13,13 +14,15 @@ class StorageInfo(BaseModel):
     format: str
     file_name: str
     encoding: str
+    
 
-
-class FileDumpInfo(BaseModel):
-    """Information about the file dump"""
+class PageLog(BaseModel):
+    """model for easily updating and logging information about the processing of a given page"""
 
     page: NonNegativeInt
-    storage_info: StorageInfo
+    storage_info: Optional[StorageInfo] = None
+    is_last: Optional[bool] = False
+    success: Optional[bool] = False
 
 
 class MetadataInfo(BaseModel):
@@ -27,10 +30,13 @@ class MetadataInfo(BaseModel):
 
     domain: str
     source: str
+    operation: str
     last_run_time: str
-    last_page_downloaded: NonNegativeInt
-    successfully_completed: bool
-    file_dumps: list[FileDumpInfo]
+    last_processed_page: NonNegativeInt
+    complete: bool
+    errors: int
+    model: DomainModel
+    pages: list[PageLog]
 
 
 class IDataHandler(Protocol):
@@ -47,6 +53,6 @@ class IDataHandler(Protocol):
         self, model: DomainModel, *args, data: Any, **kwargs
     ) -> StorageInfo: ...
 
-    def json_load(self, filedump: FileDumpInfo, *args, **kwargs) -> dict: ...
+    def json_load(self, page_log: PageLog, *args, **kwargs) -> dict: ...
 
-    def csv_load(self, filedump: FileDumpInfo, *args, **kwargs) -> DataFrame: ...
+    def csv_load(self, page_log: PageLog, *args, **kwargs) -> DataFrame: ...

--- a/common/utils/interfaces/data_loader.py
+++ b/common/utils/interfaces/data_loader.py
@@ -1,11 +1,14 @@
 from abc import ABC, abstractmethod
 
 import orjson
-from pydantic import ValidationError
+import datetime
+from pydantic import ValidationError, BaseModel, Field
+from typing import Generator, Optional
 
 from common.data_source_model import DataSourceModel, DomainModel
+from common.utils.database_client import DatabaseClient
 from common.utils.file_handler import FileHandler
-from common.utils.interfaces.data_handler import MetadataInfo
+from common.utils.interfaces.data_handler import MetadataInfo, PageLog
 from common.utils.logging_odis import logger
 
 
@@ -22,10 +25,68 @@ class AbstractDataLoader(ABC):
         self.model = model
 
         self.handler = FileHandler()
-        self.metadata_handler = FileHandler(file_name=f"{model.name}_extract_log.json")
+        self.metadata_handler = FileHandler(file_name=f"{model.name}_metadata_extract.json")
+
+    def execute(self, overwrite_table: bool = True):
+
+        if overwrite_table:
+            # create bronze table drop if it already exists
+            self.create_or_overwrite_table()
+
+        start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        last_processed_page = 0
+        page_logs = []
+        errors = 0
+        complete = False
+
+        # load actual data from metadata
+        metadata = self.load_metadata()
+
+        # execute loader iterations and log results in metadata
+        for result in self.load_data(metadata.pages):
+            
+            last_processed_page += 1
+
+            if not result.success:
+                errors += 1
+          
+            page_logs.append(result)
+        
+        # if the loop completes, extraction is successful
+        complete = True
+
+        # Export metadata info
+        # just go through pydantic to ensure the data is valid
+        # and process eventual inner things
+        load_metadata = MetadataInfo(
+            **{
+                "domain": self.config.get_domain_name(self.model),
+                "source": self.model.name,
+                "operation": 'load_data',
+                "last_run_time": start_time.isoformat(),
+                "last_processed_page": last_processed_page,
+                "complete": complete,
+                "errors": errors,
+                "model": self.model,
+                "pages": page_logs
+            }
+        ).model_dump( 
+            mode = "json" 
+        ) 
+
+        # Dump the Load metadata into a new file
+        meta_info = self.handler.file_dump(
+            self.model,
+            data = load_metadata,
+            suffix = "metadata_load"
+            )
+
+        logger.debug(
+            f"Metadata written in: '{meta_info.location}/{meta_info.file_name}'"
+        )
 
     @abstractmethod
-    def load_data(self):
+    def load_data(self) -> Generator[PageLog, None, None]:
         pass
 
     def load_metadata(self) -> MetadataInfo:
@@ -56,3 +117,28 @@ class AbstractDataLoader(ABC):
             logger.exception(f"Error reading file {metadata_filepath}: {str(e)}")
 
         raise
+
+    def create_or_overwrite_table(self):
+        """Creates the target Bronze table.
+        If exists, drops table to recreate"""
+
+        # domain_name = self.config.get_domain_name(self.model)
+
+        # initiate database session
+        db = DatabaseClient(autocommit=False)
+
+        # create bronze table drop if it already exists
+        # table_name = f"{domain_name}_{self.model.table_name}"
+
+        logger.info(f"Creating table bronze.{self.model.table_name}")
+
+        db.execute(f"DROP TABLE IF EXISTS bronze.{self.model.table_name}")
+        db.execute(
+            f"""
+            CREATE TABLE bronze.{self.model.table_name} (
+                id SERIAL PRIMARY KEY,
+                data JSONB,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)
+        """
+        )
+        db.commit()

--- a/common/utils/source_extractors.py
+++ b/common/utils/source_extractors.py
@@ -36,7 +36,7 @@ class FileExtractor(AbstractSourceExtractor):
         response = requests.get(
             self.url,
             headers=self.model.headers.model_dump(mode="json"),
-            params=self.model.params,
+            params=self.model.extract_params,
         )
         response.raise_for_status()
         payload = response.json() if self.is_json else response.content
@@ -83,7 +83,7 @@ class MelodiExtractor(FileExtractor):
 
         # if url has a query string, ignore the dict-defined parameters
         url_querystr = urllib.parse.urlparse(url).query
-        passed_params = self.model.params if url_querystr == "" else None
+        passed_params = self.model.extract_params if url_querystr == "" else None
         logger.info(f"querying '{url}'")
 
         # Send request to API

--- a/datasources.yaml
+++ b/datasources.yaml
@@ -70,7 +70,7 @@ domains:
       endpoint: /stmt/defmexp?li=0&mm=0&pp=202001-&ss=1
       type: FileExtractor
       format: csv
-      params:
+      extract_params:
         separator: ;
         header: 3
         skipfooter: 3
@@ -80,7 +80,7 @@ domains:
       endpoint: /stmt/defmexp?lj=0&mm=0&pp=202001-&ss=1
       type: FileExtractor
       format: csv
-      params:
+      extract_params:
         separator: ;
         header: 3
         skipfooter: 3
@@ -90,7 +90,7 @@ domains:
       endpoint: /stmt/defmexp?lk=0&mm=0&pp=202001-&ss=1
       type: FileExtractor
       format: csv
-      params:
+      extract_params:
         separator: ;
         header: 3
         skipfooter: 3
@@ -103,7 +103,7 @@ domains:
       type: MelodiExtractor
       endpoint: /catalog/datasets/donnees-du-repertoire-national-des-elus/records
       format: json
-      params:
+      extract_params:
         limit: 100
       response_map:
         data: results
@@ -114,7 +114,7 @@ domains:
       type: JsonExtractor
       endpoint: /catalog/datasets/donnees-du-repertoire-national-des-elus/records
       format: json
-      params:
+      extract_params:
         limit: 100
       response_map:
         data: results
@@ -161,7 +161,7 @@ domains:
         type: MelodiExtractor
         endpoint: /datasets
         format: json
-        params:
+        extract_params:
           page: 1
           pageSize: all
         response_map:
@@ -187,7 +187,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -211,7 +211,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -235,7 +235,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -259,7 +259,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -283,7 +283,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -307,7 +307,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_RP_LOGEMENT_PRINC
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2021
           GEO: ["COM", "DEP", "REG"]
@@ -333,7 +333,7 @@ domains:
         type: JsonExtractor
         endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
         format: json
-        params:
+        extract_params:
           select: commune,SUM(nombre_total_eleves)/SUM(nombre_total_classes) AS moyenne_eleves_par_classe
           group_by: commune
           limit: -1
@@ -346,7 +346,7 @@ domains:
         type: JsonExtractor
         endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
         format: json
-        params:
+        extract_params:
           select: region_academique,SUM(nombre_total_eleves)/SUM(nombre_total_classes) AS moyenne_eleves_par_classe
           group_by: region_academique
           limit: -1
@@ -359,7 +359,7 @@ domains:
         type: JsonExtractor
         endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
         format: json
-        params:
+        extract_params:
           select: departement,SUM(nombre_total_eleves)/SUM(nombre_total_classes) AS moyenne_eleves_par_classe
           group_by: departement
           limit: -1
@@ -375,7 +375,7 @@ domains:
         type: MelodiExtractor
         endpoint: /data/DS_BPE
         format: json
-        params:
+        extract_params:
           maxResult: 10000
           TIME_PERIOD: 2023
           GEO: ["COM","REG","DEP"]

--- a/datasources.yaml
+++ b/datasources.yaml
@@ -173,10 +173,13 @@ domains:
         type: FileExtractor
         endpoint: /datafiles/a0ae7112-5184-4ad7-842d-87b09fd27df1/csv
         format: csv
-        params:
+        extract_params:
           withColumnName: true
           withColumnDescription: true
           withColumnUnit: true
+        load_params:
+          header: 2
+          skipfooter: 0
 
       logements_total:
         API: INSEE.Melodi


### PR DESCRIPTION
C'est réparé :) 

Réadapté la refacto de Guillaume pour garder le même comportement sur les json loaders

Les Loaders utilisent le même format d'échange de metadata que les extractors

Preneur de retours sur la résilience du code, testé de mon côté sur le cas logement_logements_maisons