### PR TITLE
Emploi - Remplacement emploi.eff_secteur_prive_gds_secteurs json par csv

### DIFF
--- a/datasources.yaml
+++ b/datasources.yaml
@@ -82,9 +82,9 @@ domains:
     eff_secteur_prive_gds_secteurs:
       API: URSSAF
       description : Effectifs salariés du secteur privé par grands secteurs
-      type: JsonExtractor
-      endpoint: /catalog/datasets/etablissements-et-effectifs-salaries-au-niveau-commune-x-ape-last/exports/json
-      format: json
+      type: FileExtractor
+      endpoint: /catalog/datasets/etablissements-et-effectifs-salaries-au-niveau-commune-x-ape-last/exports/csv
+      format: csv
     
     demandeur_emploi_regions:
       API: statistiques.francetravail.org


### PR DESCRIPTION
[](url)Problème de OOM killed lors de l'export d'un doc json trop lourd rencontré par @Jean-Baptiste-N 

```
(venv) ➜  13_odis git:(dbt_transfo_silver) poetry run bin/odis.py extract --sources emploi.eff_secteur_prive_gds_secteurs
2025-04-03 16:14:46,736 - main - DEBUG :: extractor.py :: Processing data from https://open.urssaf.fr/api/explore/v2.1/catalog/datasets/etablissements-et-effectifs-salaries-au-niveau-commune-x-ape-last/exports/json
[1]    17879 killed     poetry run bin/odis.py extract --sources emploi.eff_secteur_prive_gds_secteur
```

Remplace de la source json  (plusieurs Go) par une source csv moins volumineuse (500mo), chez moi l'extract et le load fonctionne 

<img width="861" alt="Capture d’écran 2025-04-03 à 22 24 08" src="https://github.com/user-attachments/assets/e171c392-34f3-43fa-a42d-3e851bafea08" />

temps d'extraction 4min (connection tel 5G), et de load 9min.

Il y aura surement un sujet de gestion d'extraction par stream et de load par batch pour alléger le travail en mémoire/ load sur des fichiers plus volumineux (FYI @kloudkrafts ) mais pas sur qu'on ai plus lourd.