### PR TITLE
Lancement d'un extract / load par domain

### DIFF
--- a/bin/odis.py
+++ b/bin/odis.py
@@ -256,7 +256,6 @@ def extract(
 ):
     """
     Extract data from the data sources specified in the config file.
-    This function will extract data from the data sources specified in the config file
     \n
     - if the user specifies the sources, it will extract data from the specified sources\n
     - if the user specifies the domains, it will extract data from the data sources in the specified domains\n
@@ -364,6 +363,15 @@ def load(
         ),
     ] = DEFAULT_CONFIGFILE,
 ):
+    """
+    Load data from the data sources specified in the config file.
+    \n
+    - if the user specifies the sources, it will load data from the specified sources\n
+    - if the user specifies the domains, it will load data from the data sources in the specified domains\n
+    - if the user specifies both, it will load data from the specified sources and domains
+    \n
+    At least one of the two options must be specified.
+    """
 
     if source == OPTION_NONE and domain == OPTION_NONE:
         print(

--- a/bin/odis.py
+++ b/bin/odis.py
@@ -325,6 +325,9 @@ def extract(
         print(
             "[red]There was an issue in extracting data, please check the logs for more details.[/red]"
         )
+        # exit with a non-zero status code
+        # to indicate that there was an error
+        sys.exit(1)
     else:
         print("\n")
         print("[green]All data extracted successfully[/green]")
@@ -420,6 +423,9 @@ def load(
         print(
             "[red]There was an issue in loading data, please check the logs for more details.[/red]"
         )
+        # exit with a non-zero status code
+        # to indicate that there was an error
+        sys.exit(1)
     else:
         print("\n")
         print("[green]All data loaded successfully[/green]")

--- a/bin/odis.py
+++ b/bin/odis.py
@@ -73,7 +73,7 @@ def explain_domain(config_model: DataSourceModel, domain: str):
 
 def explain_api(config_model: DataSourceModel, api: str):
 
-    apis_list = apis_from_name(config_model, apis=api)
+    apis_list = apis_from_str(config_model, apis=api)
 
     table = Table("API", "Description", "Used by data source")
     for a in apis_list:
@@ -231,10 +231,19 @@ def extract(
         typer.Option(
             "-s",
             "--source",
-            help="comma separated list of data sources to be explained",
+            help="comma separated list of data sources to be extracted, special value '*' for all data sources",
             metavar="source_1,source_2",
         ),
-    ],
+    ] = OPTION_NONE,
+    domain: Annotated[
+        str,
+        typer.Option(
+            "-d",
+            "--domain",
+            help="comma separated list of domains to be extracted, special value '*' for all domains",
+            metavar="domain_1,domain_2",
+        ),
+    ] = OPTION_NONE,
     config: Annotated[
         str | None,
         typer.Option(
@@ -245,9 +254,44 @@ def extract(
         ),
     ] = DEFAULT_CONFIGFILE,
 ):
+    """
+    Extract data from the data sources specified in the config file.
+    This function will extract data from the data sources specified in the config file
+    \n
+    - if the user specifies the sources, it will extract data from the specified sources\n
+    - if the user specifies the domains, it will extract data from the data sources in the specified domains\n
+    - if the user specifies both, it will extract data from the specified sources and domains
+    \n
+    At least one of the two options must be specified.
+    """
+
+    if source == OPTION_NONE and domain == OPTION_NONE:
+        print(
+            "[red]You must specify at least one of the two options: --source or --domain[/red]"
+        )
+        sys.exit(1)
+
     config_model: DataSourceModel = load_config(config, response_model=DataSourceModel)
-    data_sources: list[DomainModel] = data_sources_from_name(
-        config_model, sources=source
+
+    data_sources = []
+
+    # get the data sources from the domains
+    if domain is not None:
+        data_sources = data_sources_from_domains_str(config_model, domains=domain)
+
+    # eventually, get the data sources from the sources
+    # if the user specified the sources, we want to add them to the list
+    if source is not None:
+        data_sources.extend(data_sources_from_str(config_model, sources=source))
+
+    if len(data_sources) == 0:
+        print(
+            "[red]No data sources found, please check the config file and the options provided.[/red]"
+        )
+        sys.exit(1)
+
+    print(
+        f"[green]Extracting data from the following data sources: {[ds.name for ds in data_sources]}[/green]"
     )
 
     with typer.progressbar(data_sources) as progress:
@@ -294,10 +338,19 @@ def load(
         typer.Option(
             "-s",
             "--source",
-            help="comma separated list of data sources to be explained",
-            metavar="source_1",
+            help="comma separated list of data sources to be loaded, special value '*' for all data sources",
+            metavar="source_1,source_2",
         ),
-    ],
+    ] = OPTION_NONE,
+    domain: Annotated[
+        str,
+        typer.Option(
+            "-d",
+            "--domain",
+            help="comma separated list of domains to be loaded, special value '*' for all domains",
+            metavar="domain_1,domain_2",
+        ),
+    ] = OPTION_NONE,
     config: Annotated[
         str | None,
         typer.Option(
@@ -308,9 +361,34 @@ def load(
         ),
     ] = DEFAULT_CONFIGFILE,
 ):
+
+    if source == OPTION_NONE and domain == OPTION_NONE:
+        print(
+            "[red]You must specify at least one of the two options: --source or --domain[/red]"
+        )
+        sys.exit(1)
+
+    data_sources = []
+
     config_model: DataSourceModel = load_config(config, response_model=DataSourceModel)
-    data_sources: list[DomainModel] = data_sources_from_name(
-        config_model, sources=source
+
+    # get the data sources from the domains
+    if domain is not None:
+        data_sources = data_sources_from_domains_str(config_model, domains=domain)
+
+    # eventually, get the data sources from the sources
+    # if the user specified the sources, we want to add them to the list
+    if source is not None:
+        data_sources.extend(data_sources_from_str(config_model, sources=source))
+
+    if len(data_sources) == 0:
+        print(
+            "[red]No data sources found, please check the config file and the options provided.[/red]"
+        )
+        sys.exit(1)
+
+    print(
+        f"[green]Loading data from the following data sources: {[ds.name for ds in data_sources]}[/green]"
     )
 
     with typer.progressbar(data_sources) as progress:
@@ -348,7 +426,7 @@ def load(
         print("\n")
 
 
-def apis_from_name(
+def apis_from_str(
     config: DataSourceModel,
     apis: str | None = OPTION_NONE,
 ) -> list[APIModel]:
@@ -387,7 +465,7 @@ def apis_from_name(
     return apis
 
 
-def data_sources_from_name(
+def data_sources_from_str(
     config: DataSourceModel,
     sources: str | None = OPTION_NONE,
 ) -> list[DomainModel]:
@@ -415,6 +493,45 @@ def data_sources_from_name(
     data_sources = list(
         {k: v for k, v in config.get_models().items() if k in sources_list}.values()
     )
+
+    return data_sources
+
+
+def data_sources_from_domains_str(
+    config: DataSourceModel,
+    domains: str | None = OPTION_NONE,
+) -> list[DomainModel]:
+    """
+    Parse the `domains` string and returns a list of corresponding DomainModel objects.
+
+    Args:
+        config (DataSourceModel): The config object containing the sources
+        domains (str | None): A comma separated list of domains
+
+    Returns:
+        list[DomainModel]: A list of DomainModel objects
+
+    """
+
+    if domains is not None and domains != OPTION_ALL:
+
+        # Split the comma separated string into a list
+        domains_list = [domain.strip() for domain in domains.split(",")]
+
+    elif domains == OPTION_ALL:
+        # If the user input is "*", we want all sources
+        domains_list = list(config.domains.keys())
+
+    data_sources = []
+    for d in domains_list:
+        try:
+            data_sources.extend(list(config.domains[d].values()))
+        except KeyError:
+            print("\n")
+            print(
+                f"[bold][red]Domain '{d}' not found in the config file, skipping it[/red][/bold]"
+            )
+            print("\n")
 
     return data_sources
 

--- a/bin/tests/test_odis_cli.py
+++ b/bin/tests/test_odis_cli.py
@@ -2,7 +2,7 @@ from unittest.mock import mock_open, patch
 
 from typer.testing import CliRunner
 
-from bin.odis import app, data_sources_from_name
+from bin.odis import app, data_sources_from_domains_str, data_sources_from_str
 from common.config import load_config
 from common.data_source_model import DataSourceModel
 
@@ -109,7 +109,7 @@ def test_explain_source_models():
     assert result.exit_code == 0
 
 
-def test_extract_data():
+def test_extract_by_source():
     # given
 
     yaml_config = """
@@ -152,7 +152,109 @@ def test_extract_data():
     mock_create_extractor.assert_called_once()
 
 
-def test_load_data():
+def test_extract_by_domain():
+    # given
+
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/regions
+                description: Référentiel géographique INSEE - niveau régional
+                
+            departements:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/departements
+                description: Référentiel géographique INSEE - niveau départemental
+
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function), patch(
+        "bin.odis.create_extractor"
+    ) as mock_create_extractor:
+
+        # when
+        result = runner.invoke(
+            # nevermind the name of the datasource, we are using the patch
+            # we just make sure not to load the default config
+            app,
+            ["extract", "-d", "geographical_references", "-c", "test.yaml"],
+        )
+
+    # then
+    # no exception raised but handler is not called
+    assert result.exit_code == 0
+    assert "All data extracted successfully" in result.stdout
+    assert mock_create_extractor.call_count == 2  # one for each domain
+
+
+def test_extract_all_domains():
+    # given
+
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/regions
+                description: Référentiel géographique INSEE - niveau régional
+                
+                
+        education:
+            moyenne_eleve_commune:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                description: moyenne d'eleve par classe par commune
+                
+            
+
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function), patch(
+        "bin.odis.create_extractor"
+    ) as mock_create_extractor:
+
+        # when
+        result = runner.invoke(
+            # nevermind the name of the datasource, we are using the patch
+            # we just make sure not to load the default config
+            app,
+            ["extract", "-d", "*", "-c", "test.yaml"],
+        )
+
+    # then
+    # no exception raised but handler is not called
+    assert result.exit_code == 0
+    assert "All data extracted successfully" in result.stdout
+    assert mock_create_extractor.call_count == 2  # one for each domain
+
+
+def test_load_data_by_source():
     # given
 
     yaml_config = """
@@ -195,7 +297,109 @@ def test_load_data():
     mock_create_loader.assert_called_once()
 
 
-def test_data_sources_from_name_with_spaces():
+def test_load_by_domain():
+    # given
+
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/regions
+                description: Référentiel géographique INSEE - niveau régional
+                
+            departements:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/departements
+                description: Référentiel géographique INSEE - niveau départemental
+
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function), patch(
+        "bin.odis.create_loader"
+    ) as mock_create_loader:
+
+        # when
+        result = runner.invoke(
+            # nevermind the name of the datasource, we are using the patch
+            # we just make sure not to load the default config
+            app,
+            ["load", "-d", "geographical_references", "-c", "test.yaml"],
+        )
+
+    # then
+    # no exception raised but handler is not called
+    assert result.exit_code == 0
+    assert "All data loaded successfully" in result.stdout
+    assert mock_create_loader.call_count == 2  # one for each domain
+
+
+def test_load_all_domains():
+    # given
+
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /geo/regions
+                description: Référentiel géographique INSEE - niveau régional
+                
+                
+        education:
+            moyenne_eleve_commune:
+                API: INSEE.Metadonnees
+                type: StubExtractor # nevermind the type, we are using the patch
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                description: moyenne d'eleve par classe par commune
+                
+            
+
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function), patch(
+        "bin.odis.create_loader"
+    ) as mock_create_loader:
+
+        # when
+        result = runner.invoke(
+            # nevermind the name of the datasource, we are using the patch
+            # we just make sure not to load the default config
+            app,
+            ["load", "-d", "*", "-c", "test.yaml"],
+        )
+
+    # then
+    # no exception raised but handler is not called
+    assert result.exit_code == 0
+    assert "All data loaded successfully" in result.stdout
+    assert mock_create_loader.call_count == 2  # one for each domain
+
+
+def test_data_sources_from_str_with_spaces():
     # given
     yaml_config = """
     APIs:
@@ -238,7 +442,7 @@ def test_data_sources_from_name_with_spaces():
             "test.yaml",  # this is just a dummy name, we are using the mocked_open_function
             response_model=DataSourceModel,
         )
-        result = data_sources_from_name(
+        result = data_sources_from_str(
             config_model,
             "geographical_references.regions, geographical_references.departements",
         )
@@ -247,3 +451,260 @@ def test_data_sources_from_name_with_spaces():
     assert len(result) == 2
     assert result[0].name == "geographical_references.regions"
     assert result[1].name == "geographical_references.departements"
+
+
+def test_data_sources_from_domains_str_nominal():
+    # given
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau régional
+                type: MelodiExtractor
+                endpoint: /geo/regions
+
+            departements:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau départemental
+                type: MelodiExtractor
+                endpoint: /geo/departements
+                
+
+            communes:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique GEO - niveau commune
+                type: JsonExtractor
+                endpoint: /communes?fields=code,nom,population,departement,region,centre
+                format: json
+                
+        education:
+            moyenne_eleve_commune:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par commune
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_region:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par region academique
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_departement:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par departement
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+        services:
+            services:
+                API: INSEE.Metadonnees
+                description: toto
+                type: MelodiExtractor
+                endpoint: /data/DS_BPE
+                
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function):
+        config_model = load_config(
+            "test.yaml",  # this is just a dummy name, we are using the mocked_open_function
+            response_model=DataSourceModel,
+        )
+        result = data_sources_from_domains_str(
+            config_model,
+            "education, services",
+        )
+
+    # then
+    assert len(result) == 4
+    assert result[0].name == "education.moyenne_eleve_commune"
+    assert result[1].name == "education.moyenne_eleve_region"
+    assert result[2].name == "education.moyenne_eleve_departement"
+    assert result[3].name == "services.services"
+
+
+def test_data_sources_from_domains_str_all():
+    # given
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau régional
+                type: MelodiExtractor
+                endpoint: /geo/regions
+
+            departements:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau départemental
+                type: MelodiExtractor
+                endpoint: /geo/departements
+                
+
+            communes:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique GEO - niveau commune
+                type: JsonExtractor
+                endpoint: /communes?fields=code,nom,population,departement,region,centre
+                format: json
+                
+        education:
+            moyenne_eleve_commune:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par commune
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_region:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par region academique
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_departement:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par departement
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+        services:
+            services:
+                API: INSEE.Metadonnees
+                description: toto
+                type: MelodiExtractor
+                endpoint: /data/DS_BPE
+                
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function):
+        config_model = load_config(
+            "test.yaml",  # this is just a dummy name, we are using the mocked_open_function
+            response_model=DataSourceModel,
+        )
+        result = data_sources_from_domains_str(
+            config_model,
+            "*",
+        )
+
+    # then
+    assert len(result) == 7
+    assert all(
+        source.name
+        in [
+            "geographical_references.regions",
+            "geographical_references.departements",
+            "geographical_references.communes",
+            "education.moyenne_eleve_commune",
+            "education.moyenne_eleve_region",
+            "education.moyenne_eleve_departement",
+            "services.services",
+        ]
+        for source in result
+    )
+
+
+def test_data_sources_from_domains_unknow_domain():
+    # given
+    yaml_config = """
+    APIs:
+        INSEE.Metadonnees:
+            name: Metadonnees INSEE
+            description: INSEE - API des métadonnées
+            base_url: https://api.insee.fr/metadonnees/V1
+            apidoc: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=M%C3%A9tadonn%C3%A9es&version=V1&provider=insee
+
+
+    domains:
+        geographical_references:
+            regions:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau régional
+                type: MelodiExtractor
+                endpoint: /geo/regions
+
+            departements:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique INSEE - niveau départemental
+                type: MelodiExtractor
+                endpoint: /geo/departements
+                
+
+            communes:
+                API: INSEE.Metadonnees
+                description: Référentiel géographique GEO - niveau commune
+                type: JsonExtractor
+                endpoint: /communes?fields=code,nom,population,departement,region,centre
+                format: json
+                
+        education:
+            moyenne_eleve_commune:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par commune
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_region:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par region academique
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+
+            moyenne_eleve_departement:
+                API: INSEE.Metadonnees
+                description: moyenne d'eleve par classe par departement
+                type: JsonExtractor
+                endpoint: /fr-en-ecoles-effectifs-nb_classes/exports/json
+                
+        services:
+            services:
+                API: INSEE.Metadonnees
+                description: toto
+                type: MelodiExtractor
+                endpoint: /data/DS_BPE
+                
+    """
+    mocked_open_function = mock_open(read_data=yaml_config)
+
+    # when
+    with patch("builtins.open", mocked_open_function):
+        config_model = load_config(
+            "test.yaml",  # this is just a dummy name, we are using the mocked_open_function
+            response_model=DataSourceModel,
+        )
+        result = data_sources_from_domains_str(
+            config_model,
+            "education, blah",
+        )
+
+    # then
+    assert len(result) == 3
+    assert result[0].name == "education.moyenne_eleve_commune"
+    assert result[1].name == "education.moyenne_eleve_region"
+    assert result[2].name == "education.moyenne_eleve_departement"


### PR DESCRIPTION
hello, désormais on peut faire ce genre de truc:

```sh
# lancer tout un domaine
poetry run bin/odis.py extract -d education

# idem pour load
poetry run bin/odis.py load -d education

# lancer tout le domaine education + la datasource geographical_references.regions
poetry run bin/odis.py extract -d education -s geographical_references.regions

# idem pour load...

# lancer tous les domaines
poetry run bin/odis.py extract -d '*'

# idem pour load...

```

De plus, si un extract ou load se passe mal, on continue mais on sort avec un statut `1` (et non `0`)


Et bien sur on a de l'aide sur le CLI quand on fait 
```sh
poetry run bin/odis.py extract --help

# idem pour load
```