### PR TITLE
Découpage du file handler en plus petites classes

### DIFF
--- a/common/tests/test_file_handler.py
+++ b/common/tests/test_file_handler.py
@@ -6,8 +6,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from common.data_source_model import DataSourceModel
-from common.utils.exceptions import InvalidCSV
-from common.utils.file_handler import FileHandler
+from common.utils.file_handler import FileHandler, ImporterException
 from common.utils.interfaces.data_handler import OperationType, PageLog, StorageInfo
 
 
@@ -113,7 +112,6 @@ def test_file_name_increment():
 
 
 def test_dump_metadata_with_csv_format(stub_page_log):
-
     mock_open_func = mock_open()
 
     # given
@@ -372,7 +370,7 @@ def test_load_csv_raises_invalid_csv():
     )
 
     # when
-    with pytest.raises(InvalidCSV) as e:
+    with pytest.raises(ImporterException) as e:
         file_handler.csv_load(page_log.storage_info, model)
 
     # then

--- a/common/utils/file_handler.py
+++ b/common/utils/file_handler.py
@@ -64,7 +64,7 @@ class FileReader(ABC):
         raise ImporterException(f"Error loading '{self.import_path}'")
 
 
-class CsvLoader(FileReader):
+class CsvReader(FileReader):
     def __init__(self, import_path: str):
         self.import_path = import_path
 
@@ -358,7 +358,7 @@ class FileHandler(IDataHandler):
 
         filepath = Path(storage_info.location) / Path(storage_info.file_name)
 
-        return CsvLoader(filepath).load(model=model)
+        return CsvReader(filepath).load(model=model)
 
     def xlsx_load(
         self,


### PR DESCRIPTION
Quand j'ai voulu intégrer S3 dans les entrées/sorties possibles du File handler je me suis heurtée au fait que la classe FileHandler a un côté un peu trop responsabliités multiples, ce qui faisait que je n'étais pas sûre d'implémenter correctement mes modifications et que les tester serait complexe

Ici je propose une refacto assez simple, et à un détail d'exception près complètement rétrocompatible pour le moment, qui consiste à isoler les parties "système" du reste du code dans des classes spécifiques. Ce qui rend plus évident les parties à mocker dans le test (les try_xxx)

Je met la PR comme proposition qui peut être mergée telle quelle, qui m'a pris assez peu de temps mais qui peut servir de base à une discussion si vous préférez l'actuel (et pourquoi), ou pousser plus loin cette clarification, revoir la structure de fichier ou que sais-je.