### PR TITLE
feat: logement social bronze to silver to gold

### DIFF
--- a/dbt_odis/macros/build_historical_indicator_cte.sql
+++ b/dbt_odis/macros/build_historical_indicator_cte.sql
@@ -1,0 +1,57 @@
+{% macro build_historical_indicator_cte(relation, geo_cols, unsuffixed_col_name, suffix_prefix, exclusion_prefixes=[]) %}
+  {%- set columns = adapter.get_columns_in_relation(relation) -%}
+  {%- set years = [] -%}
+  {%- set geo_cols_str = geo_cols | join(', ') %}
+  {%- set union_blocks = [] %}
+
+  {# Identify the latest available year from historical columns #}
+  {% for col in columns %}
+    {% if col.name.startswith(suffix_prefix) and col.name != unsuffixed_col_name %}
+    {% set exclude_check = namespace(flag=false) %}
+      {% for prefix in exclusion_prefixes %}
+        {% if col.name.startswith(prefix) %}
+          {% set exclude_check.flag = true %}
+        {% endif %}
+      {% endfor %}
+
+      {% if not exclude_check.flag %}
+        {% set extracted_year = extract_year_logement_logements_sociaux(col.name) %}
+        {% if extracted_year is not none %}
+          {% do years.append(extracted_year | int) %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% set latest_year = years | max if years | length > 0 else none %}
+  {% set next_year = (latest_year + 1) if latest_year else none %}
+
+  {# Include unsuffixed column, assuming it represents the next year #}
+  {% for col in columns %}
+    {% if col.name == unsuffixed_col_name and next_year is not none %}
+      {% set sql = "SELECT " ~ geo_cols_str ~ ", " ~ next_year ~ " AS year, " ~ unsuffixed_col_name ~ " AS indicateur FROM " ~ relation %}
+      {% do union_blocks.append(sql) %}
+    {% endif %}
+  {% endfor %}
+
+  {# Filter historical columns again for final SELECTs #}
+  {% for col in columns %}
+    {% if col.name.startswith(suffix_prefix) and col.name != unsuffixed_col_name %}
+      {% set exclude_check = namespace(flag=false) %}
+      {% for prefix in exclusion_prefixes %}
+        {% if col.name.startswith(prefix) %}
+          {% set exclude_check.flag = true %}
+        {% endif %}
+      {% endfor %}
+      {% if not exclude_check.flag %}
+        {% set extracted_year = extract_year_logement_logements_sociaux(col.name) %}
+        {% if extracted_year is not none %}
+          {% set sql = "SELECT " ~ geo_cols_str ~ ", " ~ extracted_year ~ " AS year, " ~ col.name ~ " AS indicateur FROM " ~ relation %}
+          {% do union_blocks.append(sql) %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {{ return(union_blocks | join('\nUNION ALL\n')) }}
+{% endmacro %}

--- a/dbt_odis/macros/build_static_indicator_cte.sql
+++ b/dbt_odis/macros/build_static_indicator_cte.sql
@@ -1,0 +1,30 @@
+{% macro build_static_indicator_cte(relation, geo_cols, static_cols) %}
+  {% if execute %}
+    {%- set columns = adapter.get_columns_in_relation(relation) -%}
+    {%- set geo_cols_str = geo_cols | join(', ') %}
+
+    {# Use helper macro to infer the most recent year from historical columns #}
+    {% set current_year = infer_current_year_from_historical_columns(relation) %}
+    {%- if current_year is none %}
+        {{ exceptions.raise_compiler_error("Cannot determine next_year for static indicators.") }}
+    {%- endif %}
+
+    {# Build the select with all static_cols cast as numeric #}
+    {% set select_cols = [] %}
+    {% for col in static_cols %}
+      {% do select_cols.append(col ~ '::NUMERIC AS ' ~ col) %}
+    {% endfor %}
+
+    {% set sql %}
+      SELECT
+        {{ geo_cols_str }},
+        {{ current_year }} AS year,
+        {{ select_cols | join(', ') }}
+      FROM {{ relation }}
+    {% endset %}
+
+    {{ return(sql) }}
+  {% else %}
+    {{ return("select 1 as dummy") }}
+  {% endif %}
+{% endmacro %}

--- a/dbt_odis/macros/extract_year_logement_logements_sociaux.sql
+++ b/dbt_odis/macros/extract_year_logement_logements_sociaux.sql
@@ -1,0 +1,25 @@
+{% macro extract_year_logement_logements_sociaux(col_name) %}
+  {% set parts = col_name.split('_') %}
+  {% set last_part = parts[-1] %}
+  
+  {% if col_name | length > 4 %}
+    {# Case 1: last part is 4-digit year #}
+    {% if last_part.isdigit() and last_part | length == 4 %}
+      {% set year_int = last_part | int %}
+      {% if 1900 <= year_int <= 2099 %}
+        {{ return(last_part) }}
+      {% endif %}
+    {% endif %}
+    
+    {# Case 2: last 4 chars is year (e.g. nb_ls2023) #}
+    {% set maybe_year = col_name[-4:] %}
+    {% if maybe_year.isdigit() %}
+      {% set year_int = maybe_year | int %}
+      {% if 1900 <= year_int <= 2099 %}
+        {{ return(maybe_year) }}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  {{ return(None) }}
+{% endmacro %}

--- a/dbt_odis/macros/get_latest_year.sql
+++ b/dbt_odis/macros/get_latest_year.sql
@@ -1,0 +1,23 @@
+{% macro get_latest_year(source_table, indicator_prefix) %}
+    {% set cols = adapter.get_columns_in_relation(source('bronze', source_table)) %}
+    {% set years = [] %}
+
+    {% for col in cols %}
+        {% if col.name.startswith(indicator_prefix) %}
+            {% set year_str = col.name.replace(indicator_prefix, '') %}
+            {% if year_str.isdigit() %}
+                {% do years.append(year_str | int) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {% if years | length > 0 %}
+        {% set latest = years | max %}
+        {% do return(latest) %}
+    {% else %}
+        {% do return(none) %}
+    {% endif %}
+{% endmacro %}
+
+
+

--- a/dbt_odis/macros/infer_current_year_from_historical_columns.sql
+++ b/dbt_odis/macros/infer_current_year_from_historical_columns.sql
@@ -1,0 +1,18 @@
+{% macro infer_current_year_from_historical_columns(relation) %}
+    {% set columns = adapter.get_columns_in_relation(relation) %}
+
+    {% set years = [] %}
+
+    {% for col in columns %}
+        {% set extracted_year = extract_year_logement_logements_sociaux(col.name) %}
+        {% if extracted_year is not none %}
+            {% do years.append(extracted_year | int) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if years | length > 0 %}
+        {{ return((years | max) + 1) }}
+    {% else %}
+        {{ return(None) }}
+    {% endif %}
+{% endmacro %}

--- a/dbt_odis/models/bronze/_odis_bronze__models.yml
+++ b/dbt_odis/models/bronze/_odis_bronze__models.yml
@@ -1357,23 +1357,23 @@ models:
   - name: logement_logements_sociaux_communes
     description: CSV contenant le nombre de logements sociaux déclarés par communes
     columns:
-      - name: DEPCOM_ARM
+      - name: codgeo
         description: Code INSEE de la commune et arrondissement
         data_type: text
         quote: true
-      - name: REG
+      - name: reg
         description: Code de la région rattachée à la commune
         data_type: bigint
         quote: true
-      - name: DEP
+      - name: dep
         description: Code du épartement rattaché à la commune
         data_type: text
         quote: true
-      - name: LIBCOM_DEP
+      - name: libcom_dep
         description: Nom de la commune et numéro de département
         data_type: text
         quote: true
-      - name: LIBCOM
+      - name: libcom
         description: Nom de la commune
         data_type: text
         quote: true

--- a/dbt_odis/models/bronze/logement_logements_sociaux_communes.sql
+++ b/dbt_odis/models/bronze/logement_logements_sociaux_communes.sql
@@ -1,9 +1,17 @@
 {{ config(
     tags = ['bronze', 'logement_social'],
-    alias = 'vw_logement_social_logements_sociaux_communes'
+    alias = 'vw_logement_logements_sociaux_communes'
     )
 }}
 
-select 
-    {{ dbt_utils.star(from=source('bronze', 'logement_social_logements_sociaux_communes')) }}
+select
+    "DEPCOM_ARM" as codgeo,
+    "LIBCOM" as libcom,
+    "DEP" as dep,
+    "LIBCOM_DEP" as libcom_dep,
+    "REG" as reg, 
+    {{ dbt_utils.star(
+        from=source('bronze', 'logement_social_logements_sociaux_communes'),
+        except=["DEPCOM_ARM", "LIBCOM", "DEP", "LIBCOM_DEP", "REG"]
+    ) }}
 from {{ source('bronze', 'logement_social_logements_sociaux_communes') }}

--- a/dbt_odis/models/bronze/logement_logements_sociaux_departement.sql
+++ b/dbt_odis/models/bronze/logement_logements_sociaux_departement.sql
@@ -1,9 +1,14 @@
 {{ config(
     tags = ['bronze', 'logement_social'],
-    alias = 'vw_logement_social_logements_sociaux_departement'
+    alias = 'vw_logement_logements_sociaux_departement'
     )
 }}
 
 select 
-    {{ dbt_utils.star(from=source('bronze', 'logement_social_logements_sociaux_departement')) }}
+    "DEP" as dep,
+    "Unnamed: 1" as libdep,
+    {{ dbt_utils.star(
+        from=source('bronze', 'logement_social_logements_sociaux_departement'),
+        except=["DEP", "Unnamed: 1"]
+    ) }}
 from {{ source('bronze', 'logement_social_logements_sociaux_departement') }}

--- a/dbt_odis/models/bronze/logement_logements_sociaux_epci.sql
+++ b/dbt_odis/models/bronze/logement_logements_sociaux_epci.sql
@@ -1,9 +1,14 @@
 {{ config(
-    tags = ['bronze', 'logement_social'],
-    alias = 'vw_logement_social_logements_sociaux_epci'
-    )
-}}
+    tags=['bronze', 'logement_social'],
+    alias='vw_logement_logements_sociaux_epci'
+) }}
 
-select 
-    {{ dbt_utils.star(from=source('bronze', 'logement_social_logements_sociaux_epci')) }}
+select
+    "EPCI_DEP" as epci_dep,
+    "LIBEPCI" as libepci,
+    "DEP" as dep,
+    {{ dbt_utils.star(
+        from=source('bronze', 'logement_social_logements_sociaux_epci'),
+        except=["EPCI_DEP", "LIBEPCI", "DEP"]
+        ) }}
 from {{ source('bronze', 'logement_social_logements_sociaux_epci') }}

--- a/dbt_odis/models/bronze/logement_logements_sociaux_region.sql
+++ b/dbt_odis/models/bronze/logement_logements_sociaux_region.sql
@@ -1,9 +1,14 @@
 {{ config(
     tags = ['bronze', 'logement_social'],
-    alias = 'vw_logement_social_logements_sociaux_region'
+    alias = 'vw_logement_logements_sociaux_region'
     )
 }}
 
-select 
-    {{ dbt_utils.star(from=source('bronze', 'logement_social_logements_sociaux_region')) }}
+select
+    "REG" as reg,
+    "LIBREG" as libreg,
+    {{ dbt_utils.star(
+        from=source('bronze', 'logement_social_logements_sociaux_region'),
+        except=["REG", "LIBREG"] 
+    ) }}
 from {{ source('bronze', 'logement_social_logements_sociaux_region') }}

--- a/dbt_odis/models/gold/_odis_gold__models.yml
+++ b/dbt_odis/models/gold/_odis_gold__models.yml
@@ -50,3 +50,39 @@ models:
         description: Tranche déterminée à partir du champ population
       - name: population
         description: Nombre d'habitants dans la commune
+
+
+
+  - name: gold_logement_logements_sociaux
+    description: Table transformée contenant les indicateurs logements sociaux pour tous les niveaux géograpiques (région, département, commune, epci)
+    columns:
+      - name: codgeo
+        description: Parc complet Ensemble du parc social
+        tests:
+          - not_null
+      - name: year
+        description: Année de référence
+      - name: nb_ls
+        description: Parc complet Ensemble du parc social  
+      - name: nb_loues
+        description: Parc complet proposés à la location loués
+      - name: nb_vacants
+        description: Parc complet proposés à la location vacants
+      - name: nb_vides
+        description: Parc complet Ensemble du parc vide
+      - name: nb_asso
+        description: Parc complet pris en charge par une association
+      - name: nb_occup_finan
+        description: Parc complet occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: Parc complet occupé pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Parc complet Nombre de logements en QPV
+      - name: tx_vac
+        description: PTaux de vacance % totale Au 01/01
+      - name: tx_vac3
+        description: Taux de vacance % > 3 mois Au 01/01
+      - name: tx_mob
+        description: Taux de mobilité % Au 01/01
+      - name: densite
+        description: Parc complet Densité pour 100 résidences principales

--- a/dbt_odis/models/gold/_odis_gold__sources.yml
+++ b/dbt_odis/models/gold/_odis_gold__sources.yml
@@ -8,3 +8,9 @@ sources:
         description: Table contenant
         loaded_at_field: created_at
       
+
+
+
+
+
+      

--- a/dbt_odis/models/gold/gold_logement_logements_sociaux.sql
+++ b/dbt_odis/models/gold/gold_logement_logements_sociaux.sql
@@ -1,0 +1,21 @@
+{{ config(
+    alias='gold_logement_logements_sociaux',
+    tags=['gold', 'logement_social']
+) }}
+
+select
+    codgeo,
+    year,
+    coalesce(nb_ls, 0) as "Parc complet Ensemble du parc social",
+    coalesce(nb_loues, 0) as "Parc complet proposés à la location loués",
+    coalesce(nb_vacants, 0) as "Parc complet proposés à la location vacants",
+    coalesce(nb_vides, 0) as "Parc complet vide",
+    coalesce(nb_asso, 0) as "Parc complet pris en charge par une association",
+    coalesce(nb_occup_finan, 0) as "Parc complet occupés avec ou sans contrepartie financière",
+    coalesce(nb_occup_temp, 0) as "Parc complet occupé pour de l'hébergement temporaire",
+    coalesce(nb_ls_en_qpv, 0) as "Parc complet Nombre de logements en QPV",
+    coalesce(tx_vac, 0) as "Taux de vacance % totale Au 01/01",
+    coalesce(tx_vac3, 0) as "Taux de vacance % > 3 mois Au 01/01",
+    coalesce(tx_mob, 0) as "Taux de mobilité % Au 01/01",
+    coalesce(densite, 0) as "Parc complet Densité pour 100 résidences principales"
+  from {{ ref('silver_logement_logements_sociaux') }}

--- a/dbt_odis/models/silver/_odis_silver__models.yml
+++ b/dbt_odis/models/silver/_odis_silver__models.yml
@@ -34,6 +34,190 @@ models:
       - name: code_geo
         description: code géographique (commune, département, région).
 
+  - name: stg_logement_logements_sociaux_communes
+    description: Table transformée contenant les indicateurs logements sociaux au niveau commune
+    columns:
+      - name: codgeo
+        description: Code INSEE de la commune et arrondissement
+      - name: libcom
+        description: Nom de la commune
+      - name: dep
+        description: Code du département rattachée à la commune
+      - name: reg
+        description: Code de la région rattachée à la commune
+      - name: year
+        description: Année de référence
+      - name: type_geo
+        description: Niveau géograpique (commune, département, région, epci)
+      - name: nb_ls
+        description: "Ensemble du parc social : nombre total de logements sociaux dans la commune"
+      - name: tx_vac
+        description: Taux de vacance du parc social au 1er janvier de l'année de référence
+      - name: tx_vac3
+        description: Taux de vacance d'une période supérieure à 3 mois du parc social au 1er janvier de l'année de réference
+      - name: tx_mob
+        description: Taux de mobilité du parc social au 1er janvier de l'année de référence
+      - name: nb_loues
+        description: Nombre de logements sociaux proposés à location qui sont actuellement loués
+      - name: nb_vacants
+        description: Nombre de logements sociaux proposés à location qui sont actuellement nb_vacants
+      - name: nb_vides
+        description: Nombre de logements sociaux qui sont vides
+      - name: nb_asso
+        description: Nombre de logements sociaux qui sont pris en charge par une association
+      - name: nb_occup_finan
+        description: Nombre de logements sociaux occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: Nombre de logements sociaux occupés pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Nombre de logements sociaux en QPV (quartier prioritaire de la politique de la ville)
+      - name: densite
+        description: Densité pour 100 résidences principales (source --> RP 2021)
+      
+  - name: stg_logement_logements_sociaux_departement
+    description: Table transformée contenant les indicateurs logements sociaux au niveau département
+    columns:
+      - name: codgeo
+        description: Code Insee du département
+      - name: libdep
+        description: Nom du département
+      - name: year
+        description: Année de référence
+      - name: type_geo
+        description: Niveau géograpique (commune, département, région, epci)
+      - name: nb_ls
+        description: "Ensemble du parc social : nombre total de logements sociaux dans le département"
+      - name: tx_vac
+        description: Taux de vacance du parc social au 1er janvier de l'année de référence
+      - name: tx_vac3
+        description: Taux de vacance d'une période supérieure à 3 mois du parc social au 1er janvier de l'année de réference
+      - name: tx_mob
+        description: Taux de mobilité du parc social au 1er janvier de l'année de référence
+      - name: nb_loues
+        description: nombre de logements sociaux proposés à la location dans le département, qui sont loués
+      - name: nb_vacants
+        description: Nombre de logements sociaux proposés à location qui sont actuellement nb_vacants
+      - name: nb_vides
+        description: Nombre de logements sociaux qui sont vides
+      - name: nb_asso
+        description: Nombre de logements sociaux qui sont pris en charge par une association
+      - name: nb_occup_finan
+        description: Nombre de logements sociaux occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: Nombre de logements sociaux occupés pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Nombre de logements sociaux en QPV (quartier prioritaire de la politique de la ville)
+      - name: densite
+        description: Densité pour 100 résidences principales (source --> RP 2021)
+
+  - name: stg_logement_logements_sociaux_region
+    description: Table transformée contenant les indicateurs logements sociaux au niveau région
+    columns:
+      - name: codgeo
+        description: Code Insee de la région, précédé par 'reg' --> 'reg11' pour Ile de France
+      - name: libreg
+        description: Nom de la région
+      - name: year
+        description: Année de référence
+      - name: type_geo
+        description: Niveau géograpique (commune, département, région, epci)
+      - name: nb_ls
+        description: "Ensemble du parc social : nombre total de logements sociaux dans la région"
+      - name: tx_vac
+        description: Taux de vacance
+      - name: tx_vac3
+        description: Taux de vacance d'une période supérieure à 3 mois du parc social au 1er janvier de l'année de réference        
+      - name: tx_mob
+        description: Taux de mobilité
+      - name: nb_loues
+        description: nombre de logements sociaux proposés à la location dans la région, qui sont loués
+      - name: nb_vacants
+        description: nombre de logements sociaux proposés à la location dans la régop,, qui sont vacants
+      - name: nb_vides
+        description: nombre de logements sociaux dans la région, qui sont vides
+      - name: nb_asso
+        description: nombre de logements sociaux dans la région, qui sont pris en charge par une association
+      - name: nb_occup_finan
+        description: nombre de logements sociaux dans la région, qui sont occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: nombre de logements sociaux dans la région, qui sont occupés pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Nombre de logements sociaux en QPV (quartier prioritaire de la politique de la ville)
+      - name: densite
+        description: Densité pour 100 résidences principales (source --> RP 2021)
+
+  - name: stg_logement_logements_sociaux_epci
+    description: Table transformée contenant les indicateurs logements sociaux au niveau EPCI
+    columns:
+      - name: epci_dep
+        description: Code département + EPCI
+      - name: libepci
+        description: Nom de l’EPCI
+      - name: year
+        description: Année de référence
+      - name: type_geo
+        description: Niveau géograpique (commune, département, région, epci)
+      - name: nb_ls
+        description: "Ensemble du parc social : nombre total de logements sociaux dans la commune"
+      - name: tx_vac
+        description: Taux de vacance
+      - name: tx_vac3
+        description: Taux de vacance d'une période supérieure à 3 mois du parc social au 1er janvier de l'année de réference       
+      - name: tx_mob
+        description: Taux de mobilité
+      - name: nb_loues
+        description: Nombre de logements sociaux proposés à location qui sont actuellement loués
+      - name: nb_vacants
+        description: Nombre de logements sociaux proposés à location qui sont actuellement nb_vacants
+      - name: nb_vides
+        description: Nombre de logements sociaux qui sont vides
+      - name: nb_asso
+        description: Nombre de logements sociaux qui sont pris en charge par une association
+      - name: nb_occup_finan
+        description: Nombre de logements sociaux occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: Nombre de logements sociaux occupés pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Nombre de logements sociaux en QPV (quartier prioritaire de la politique de la ville)
+      - name: densite
+        description: Densité pour 100 résidences principales (source --> RP 2021)
+
+  - name: silver_logement_logements_sociaux
+    description: Table transformée contenant les indicateurs logements sociaux pour tous les niveaux géograpiques (région, département, commune, epci)
+    columns: 
+      - name: type_geo
+        description: Type géograpique (commune, département, région, epci)
+      - name: codgeo
+        description: Numéro rattaché au niveau géograpique (commune, département, région, epci)
+      - name: lib_geo
+        description: Nom de rattaché au niveau géographique (commune, département, région, epci)
+      - name: year
+        description: Année de référence
+      - name: nb_ls
+        description: "Ensemble du parc social : nombre total de logements sociaux dans la commune"
+      - name: tx_vac
+        description: Taux de vacance
+      - name: tx_vac3
+        description: Taux de vacance d'une période supérieure à 3 mois du parc social au 1er janvier de l'année de réference       
+      - name: tx_mob
+        description: Taux de mobilité
+      - name: nb_loues
+        description: Nombre de logements sociaux proposés à location qui sont actuellement loués
+      - name: nb_vacants
+        description: Nombre de logements sociaux proposés à location qui sont actuellement nb_vacants
+      - name: nb_vides
+        description: Nombre de logements sociaux qui sont vides
+      - name: nb_asso
+        description: Nombre de logements sociaux qui sont pris en charge par une association
+      - name: nb_occup_finan
+        description: Nombre de logements sociaux occupés avec ou sans contrepartie financière
+      - name: nb_occup_temp
+        description: Nombre de logements sociaux occupés pour de l'hébergement temporaire
+      - name: nb_ls_en_qpv
+        description: Nombre de logements sociaux en QPV (quartier prioritaire de la politique de la ville)
+      - name: densite
+        description: Densité pour 100 résidences principales (source --> RP 2021)
+
   - name: emploi_demandeur_emploi
     description: Table jointure horizontale des 3 niveaux de zones géographiques, pour les demandeurs d'emploi mesurée pour une zone donnée, mois-année en colonne
     columns:

--- a/dbt_odis/models/silver/silver_logement_logements_sociaux.sql
+++ b/dbt_odis/models/silver/silver_logement_logements_sociaux.sql
@@ -1,0 +1,101 @@
+{{ config(
+    alias='silver_logement_logements_sociaux',
+    tags=['silver', 'logement_social']
+) }}
+
+with
+
+communes as (
+  select
+    type_geo,
+    codgeo,
+    libcom as lib_geo,
+    year,
+    nb_ls,
+    tx_vac,
+    tx_vac3,
+    tx_mob,
+    nb_loues,
+    nb_vacants,
+    nb_vides,
+    nb_asso,
+    nb_occup_finan,
+    nb_occup_temp,
+    nb_ls_en_qpv,
+    densite
+  from {{ ref('stg_logement_logements_sociaux_communes') }}
+),
+
+departement as (
+  select
+    type_geo,
+    codgeo,
+    libdep as lib_geo,
+    year,
+    nb_ls,
+    tx_vac,
+    tx_vac3,
+    tx_mob,
+    nb_loues,
+    nb_vacants,
+    nb_vides,
+    nb_asso,
+    nb_occup_finan,
+    nb_occup_temp,
+    nb_ls_en_qpv,
+    densite
+  from {{ ref('stg_logement_logements_sociaux_departement') }}
+),
+
+region as (
+  select
+    type_geo,
+    codgeo,
+    libreg as lib_geo,
+    year,
+    nb_ls,
+    tx_vac,
+    tx_vac3,
+    tx_mob,
+    nb_loues,
+    nb_vacants,
+    nb_vides,
+    nb_asso,
+    nb_occup_finan,
+    nb_occup_temp,
+    nb_ls_en_qpv,
+    densite
+  from {{ ref('stg_logement_logements_sociaux_region') }}
+),
+
+epci as (
+  select
+    type_geo,
+    codgeo,
+    libepci as lib_geo,
+    year,
+    nb_ls,
+    tx_vac,
+    tx_vac3,
+    tx_mob,
+    nb_loues,
+    nb_vacants,
+    nb_vides,
+    nb_asso,
+    nb_occup_finan,
+    nb_occup_temp,
+    nb_ls_en_qpv,
+    densite
+  from {{ ref('stg_logement_logements_sociaux_epci') }}
+)
+
+select * from communes
+    union all
+select * from departement
+    union all
+select * from region
+    union all
+select * from epci
+
+
+

--- a/dbt_odis/models/silver/stg_logement_logements_sociaux_communes.sql
+++ b/dbt_odis/models/silver/stg_logement_logements_sociaux_communes.sql
@@ -1,0 +1,126 @@
+{{ config(
+    alias='stg_logement_logements_sociaux_communes',
+    tags=['silver', 'logement_social']
+) }}
+
+with
+
+-- Historical indicators pivoted long with multiple years
+nb_ls as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_communes'),
+      ['codgeo', 'libcom', 'dep', 'reg'],
+      'nb_ls',
+      'nb_ls',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+tx_vac as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_communes'),
+      ['codgeo', 'libcom', 'dep', 'reg'],
+      'tx_vac',
+      'tx_vac',
+      exclusion_prefixes=['tx_vac_3']
+  ) }}
+),
+
+tx_vac3 as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_communes'),
+      ['codgeo', 'libcom', 'dep', 'reg'],
+      'tx_vac3',
+      'tx_vac_3',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+tx_mob as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_communes'),
+      ['codgeo', 'libcom', 'dep', 'reg'],
+      'tx_mob',
+      'tx_mob',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- Static indicators only present for next_year (e.g. nb_loues, nb_vacants, etc.)
+static_indicators as (
+  {{ build_static_indicator_cte(
+      ref('logement_logements_sociaux_communes'),
+      ['codgeo', 'libcom', 'dep', 'reg'],
+      ['nb_loues', 'nb_vacants', 'nb_vides', 'nb_asso', 'nb_occup_finan', 'nb_occup_temp', 'nb_ls_en_qpv']
+  ) }}
+),
+
+-- Densite block with fixed year (2021, from last census as of 01/01/2025)
+densite_block as (
+  select
+    codgeo,
+    libcom,
+    dep,
+    reg,
+    2021 as year,
+    densite
+  from {{ ref('logement_logements_sociaux_communes') }}
+),
+
+-- Join all historical indicators + static indicators on geo + year
+joined_indicators as (
+  select
+    l.codgeo,
+    l.libcom,
+    l.dep,
+    l.reg,
+    l.year,
+    l.indicateur as nb_ls,
+    tv.indicateur as tx_vac,
+    tv3.indicateur as tx_vac3,
+    tm.indicateur as tx_mob,
+    s.nb_loues,
+    s.nb_vacants,
+    s.nb_vides,
+    s.nb_asso,
+    s.nb_occup_finan,
+    s.nb_occup_temp,
+    s.nb_ls_en_qpv
+  from nb_ls l
+  left join tx_vac tv
+    on l.codgeo = tv.codgeo and l.year = tv.year
+  left join tx_vac3 tv3
+    on l.codgeo = tv3.codgeo and l.year = tv3.year
+  left join tx_mob tm
+    on l.codgeo = tm.codgeo and l.year = tm.year
+  left join static_indicators s
+    on l.codgeo = s.codgeo and l.year = s.year
+),
+
+-- Add densite and type_geo
+final as (
+  select
+    j.codgeo,
+    j.libcom,
+    j.dep,
+    j.reg,
+    j.year,
+    'commune' as type_geo,
+    j.nb_ls,
+    j.tx_vac,
+    j.tx_vac3,
+    j.tx_mob,
+    j.nb_loues,
+    j.nb_vacants,
+    j.nb_vides,
+    j.nb_asso,
+    j.nb_occup_finan,
+    j.nb_occup_temp,
+    j.nb_ls_en_qpv,
+    d.densite
+  from joined_indicators j
+  left join densite_block d
+    on j.codgeo = d.codgeo and j.year = d.year
+)
+
+select * from final

--- a/dbt_odis/models/silver/stg_logement_logements_sociaux_departement.sql
+++ b/dbt_odis/models/silver/stg_logement_logements_sociaux_departement.sql
@@ -1,0 +1,125 @@
+{{ config(
+    alias='stg_logement_logements_sociaux_departement',
+    tags=['silver', 'logement_social']
+) }}
+
+with
+
+-- Historical indicators pivoted long with multiple years
+
+-- nb_ls
+nb_ls as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_departement'),
+      ['dep', 'libdep'],
+      'nb_ls',
+      'nb_ls',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_vac
+tx_vac as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_departement'),
+      ['dep', 'libdep'],
+      'tx_vac',
+      'tx_vac',
+      exclusion_prefixes=['tx_vac_3']
+  ) }}
+),
+
+-- tx_vac3
+tx_vac3 as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_departement'),
+      ['dep', 'libdep'],
+      'tx_vac3',
+      'tx_vac_3',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_mob
+tx_mob as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_departement'),
+      ['dep', 'libdep'],
+      'tx_mob',
+      'tx_mob',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- Static indicators only present for next_year (e.g. nb_loues, nb_vacants, etc.)
+static_indicators as (
+  {{ build_static_indicator_cte(
+      ref('logement_logements_sociaux_departement'),
+      ['dep', 'libdep'],
+      ['nb_loues', 'nb_vacants', 'nb_vides', 'nb_asso', 'nb_occup_finan', 'nb_occup_temp', 'nb_ls_en_qpv']
+  ) }}
+),
+
+-- Densite block with fixed year (2021, from last census as of 01/01/2025)
+densite_block as (
+  select
+    dep as codgeo,
+    libdep,
+    2021 as year,
+    densite
+  from {{ ref('logement_logements_sociaux_departement') }}
+),
+
+-- Join all historical indicators + static indicators on geo + year
+joined_indicators as (
+  select
+    l.dep as codgeo,
+    l.libdep,
+    l.year,
+    l.indicateur as nb_ls,
+    tv.indicateur as tx_vac,
+    tv3.indicateur as tx_vac3,
+    tm.indicateur as tx_mob,
+    s.nb_loues,
+    s.nb_vacants,
+    s.nb_vides,
+    s.nb_asso,
+    s.nb_occup_finan,
+    s.nb_occup_temp,
+    s.nb_ls_en_qpv
+  from nb_ls l
+  left join tx_vac tv
+    on l.dep = tv.dep and l.year = tv.year
+  left join tx_vac3 tv3
+    on l.dep = tv3.dep and l.year = tv3.year
+  left join tx_mob tm
+    on l.dep = tm.dep and l.year = tm.year
+  left join static_indicators s
+    on l.dep = s.dep and l.year = s.year
+),
+
+-- Add densite and type_geo
+final as (
+  select
+    j.codgeo,
+    j.libdep,
+    j.year,
+    'departement' as type_geo,
+    j.nb_ls,
+    j.tx_vac,
+    j.tx_vac3,
+    j.tx_mob,
+    j.nb_loues,
+    j.nb_vacants,
+    j.nb_vides,
+    j.nb_asso,
+    j.nb_occup_finan,
+    j.nb_occup_temp,
+    j.nb_ls_en_qpv,
+    d.densite
+  from joined_indicators j
+  left join densite_block d
+    on j.codgeo = d.codgeo and j.year = d.year
+)
+
+select * from final

--- a/dbt_odis/models/silver/stg_logement_logements_sociaux_epci.sql
+++ b/dbt_odis/models/silver/stg_logement_logements_sociaux_epci.sql
@@ -1,0 +1,128 @@
+{{ config(
+    alias='stg_logement_logements_sociaux_epci',
+    tags=['silver', 'logement_social']
+) }}
+
+with
+
+-- Historical indicators pivoted long with multiple years
+
+-- nb_ls
+nb_ls as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_epci'),
+      ['epci_dep', 'libepci', 'dep'],
+      'nb_ls',
+      'nb_ls',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_vac
+tx_vac as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_epci'),
+      ['epci_dep', 'libepci', 'dep'],
+      'tx_vac',
+      'tx_vac',
+      exclusion_prefixes=['tx_vac_3']
+  ) }}
+),
+
+-- tx_vac3
+tx_vac3 as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_epci'),
+      ['epci_dep', 'libepci', 'dep'],
+      'tx_vac3',
+      'tx_vac_3',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_mob
+tx_mob as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_epci'),
+      ['epci_dep', 'libepci', 'dep'],
+      'tx_mob',
+      'tx_mob',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- Static indicators only present for next_year (e.g. nb_loues, nb_vacants, etc.)
+static_indicators as (
+  {{ build_static_indicator_cte(
+      ref('logement_logements_sociaux_epci'),
+      ['epci_dep', 'libepci', 'dep'],
+      ['nb_loues', 'nb_vacants', 'nb_vides', 'nb_asso', 'nb_occup_finan', 'nb_occup_temp', 'nb_ls_en_qpv']
+  ) }}
+),
+
+-- Densite block with fixed year (2021, from last census as of 01/01/2025)
+densite_block as (
+  select
+    epci_dep as codgeo,
+    libepci,
+    dep,
+    2021 as year,
+    densite
+  from {{ ref('logement_logements_sociaux_epci') }}
+),
+
+-- Join all historical indicators + static indicators on geo + year
+joined_indicators as (
+  select
+    l.epci_dep as codgeo,
+    l.libepci,
+    l.dep,
+    l.year,
+    l.indicateur as nb_ls,
+    tv.indicateur as tx_vac,
+    tv3.indicateur as tx_vac3,
+    tm.indicateur as tx_mob,
+    s.nb_loues,
+    s.nb_vacants,
+    s.nb_vides,
+    s.nb_asso,
+    s.nb_occup_finan,
+    s.nb_occup_temp,
+    s.nb_ls_en_qpv
+  from nb_ls l
+  left join tx_vac tv
+    on l.epci_dep = tv.epci_dep and l.year = tv.year
+  left join tx_vac3 tv3
+    on l.epci_dep = tv3.epci_dep and l.year = tv3.year
+  left join tx_mob tm
+    on l.epci_dep = tm.epci_dep and l.year = tm.year
+  left join static_indicators s
+    on l.epci_dep = s.epci_dep and l.year = s.year
+),
+
+-- Add densite and type_geo
+final as (
+  select
+    j.codgeo,
+    j.libepci,
+    j.dep,
+    j.year,
+    'epci' as type_geo,
+    j.nb_ls,
+    j.tx_vac,
+    j.tx_vac3,
+    j.tx_mob,
+    j.nb_loues,
+    j.nb_vacants,
+    j.nb_vides,
+    j.nb_asso,
+    j.nb_occup_finan,
+    j.nb_occup_temp,
+    j.nb_ls_en_qpv,
+    d.densite
+  from joined_indicators j
+  left join densite_block d
+    on j.codgeo = d.codgeo and j.year = d.year
+)
+
+select * from final

--- a/dbt_odis/models/silver/stg_logement_logements_sociaux_region.sql
+++ b/dbt_odis/models/silver/stg_logement_logements_sociaux_region.sql
@@ -1,0 +1,127 @@
+{{ config(
+    alias='stg_logement_logements_sociaux_region',
+    tags=['silver', 'logement_social']
+) }}
+
+with
+
+-- Historical indicators pivoted long with multiple years
+
+-- nb_ls
+nb_ls as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_region'),
+      ['reg', 'libreg'],
+      'nb_ls',
+      'nb_ls',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_vac
+tx_vac as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_region'),
+      ['reg', 'libreg'],
+      'tx_vac',
+      'tx_vac',
+      exclusion_prefixes=['tx_vac_3']
+  ) }}
+),
+
+-- tx_vac3
+tx_vac3 as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_region'),
+      ['reg', 'libreg'],
+      'tx_vac3',
+      'tx_vac_3',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- tx_mob
+tx_mob as (
+  {{ build_historical_indicator_cte(
+      ref('logement_logements_sociaux_region'),
+      ['reg', 'libreg'],
+      'tx_mob',
+      'tx_mob',
+      exclusion_prefixes=[]
+  ) }}
+),
+
+-- Static indicators only present for next_year (e.g. nb_loues, nb_vacants, etc.)
+static_indicators as (
+  {{ build_static_indicator_cte(
+      ref('logement_logements_sociaux_region'),
+      ['reg', 'libreg'],
+      ['nb_loues', 'nb_vacants', 'nb_vides', 'nb_asso', 'nb_occup_finan', 'nb_occup_temp', 'nb_ls_en_qpv']
+  ) }}
+),
+
+-- Densite block with fixed year (2021, from last census as of 01/01/2025)
+densite_block as (
+  select
+    reg,
+    'reg' || cast(reg as TEXT) as codgeo,
+    libreg,
+    2021 as year,
+    densite
+  from {{ ref('logement_logements_sociaux_region') }}
+),
+
+-- Join all historical indicators + static indicators on geo + year
+joined_indicators as (
+  select
+    l.reg,
+    'reg' || cast(l.reg as TEXT) as codgeo,
+    l.libreg,
+    l.year,
+    l.indicateur as nb_ls,
+    tv.indicateur as tx_vac,
+    tv3.indicateur as tx_vac3,
+    tm.indicateur as tx_mob,
+    s.nb_loues,
+    s.nb_vacants,
+    s.nb_vides,
+    s.nb_asso,
+    s.nb_occup_finan,
+    s.nb_occup_temp,
+    s.nb_ls_en_qpv
+  from nb_ls l
+  left join tx_vac tv
+    on l.reg = tv.reg and l.year = tv.year
+  left join tx_vac3 tv3
+    on l.reg = tv3.reg and l.year = tv3.year
+  left join tx_mob tm
+    on l.reg = tm.reg and l.year = tm.year
+  left join static_indicators s
+    on l.reg = s.reg and l.year = s.year
+),
+
+-- Add densite and type_geo
+final as (
+  select
+    j.codgeo,
+    j.libreg,
+    j.year,
+    'region' as type_geo,
+    j.nb_ls,
+    j.tx_vac,
+    j.tx_vac3,
+    j.tx_mob,
+    j.nb_loues,
+    j.nb_vacants,
+    j.nb_vides,
+    j.nb_asso,
+    j.nb_occup_finan,
+    j.nb_occup_temp,
+    j.nb_ls_en_qpv,
+    d.densite
+  from joined_indicators j
+  left join densite_block d
+    on j.codgeo = d.codgeo and j.year = d.year
+)
+
+select * from final

--- a/dbt_odis/package-lock.yml
+++ b/dbt_odis/package-lock.yml
@@ -1,10 +1,10 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
-  - package: calogica/dbt_expectations
-    version: 0.10.4
+  - package: metaplane/dbt_expectations
+    version: 0.10.9
   - package: elementary-data/elementary
-    version: 0.17.0
-  - package: calogica/dbt_date
-    version: 0.10.1
-sha1_hash: e2fe04a61269cf2ea7bf807f40284b4994d175ae
+    version: 0.18.3
+  - package: godatadriven/dbt_date
+    version: 0.14.1
+sha1_hash: ef3ae10dedd2f1c89241c2e7af248c6373510c58

--- a/dbt_odis/packages.yml
+++ b/dbt_odis/packages.yml
@@ -2,8 +2,8 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
 
-  - package: calogica/dbt_expectations
-    version: 0.10.4
+  - package: metaplane/dbt_expectations
+    version: 0.10.9
 
   - package: elementary-data/elementary
-    version: 0.17.0
+    version: 0.18.3


### PR DESCRIPTION
- Mise à jour des modèles bronze :  tous les noms de colonnes ont été mis en minuscules pour assurer la compatibilité avec Postgres

- Ajout de 4 macros : 
  • build_historical_indicator_cte 
  • build_static_indicator_cte 
  • extract_year_logement_logements_sociaux 
  • infer_current_year_from_historical_columns

- Ajout de 5 modèles silver : 
  • stg_logement_logements_sociaux_communes 
  • stg_logement_logements_sociaux_departement 
  • stg_logement_logements_sociaux_region 
  • stg_logement_logements_sociaux_epci 
  • silver_logements_sociaux

- Ajout d'un modèle gold : 
   • gold_logement_logements_sociaux

- Mise à jour des fichiers yaml silver__models et gold__models